### PR TITLE
Fix order of lat/lon for generating markers

### DIFF
--- a/src/demo/app/leaflet-markercluster/markercluster-demo.component.ts
+++ b/src/demo/app/leaflet-markercluster/markercluster-demo.component.ts
@@ -71,7 +71,7 @@ export class MarkerClusterDemoComponent
 				shadowUrl: 'a0c6cc1401c107b501efee6477816891.png'
 			});
 
-			data.push(L.marker([ this.generateLon(), this.generateLat() ], { icon }));
+			data.push(L.marker([ this.generateLat(), this.generateLon() ], { icon }));
 		}
 
 		return data;


### PR DESCRIPTION
I just fell into that trap, while copying from this example. Here's the relevant leaflet code which is clear on this: https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/geo/LatLng.js#L123